### PR TITLE
Remove extra comma in rect definition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ macro_rules! rect {
     );
     (
         $left:tt $($left_unit:ident)?, $top:tt $($top_unit:ident)?,
-        $right:tt $($right_unit:ident)?, $bottom:tt $($bottom_unit:ident)?
+        $right:tt $($right_unit:ident)?, $bottom:tt $($bottom_unit:ident)? $(,)?
     ) => (
         bevy::ui::UiRect {
             left: unit!($left $($left_unit)?),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ macro_rules! rect {
     );
     (
         $left:tt $($left_unit:ident)?, $top:tt $($top_unit:ident)?,
-        $right:tt $($right_unit:ident)?, $bottom:tt $($bottom_unit:ident)?,
+        $right:tt $($right_unit:ident)?, $bottom:tt $($bottom_unit:ident)?
     ) => (
         bevy::ui::UiRect {
             left: unit!($left $($left_unit)?),


### PR DESCRIPTION
I noticed that the 4 field version of the rect macro had an extra comma at the end.
This just removes it.